### PR TITLE
fix: Home page new posts section showing oldest posts instead of newest

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,6 @@ const allBlogPosts = await getCollection("blog");
     <BlogGrid>
     {
     allBlogPosts
-    .reverse()
     .slice(0,3)
     .map((post) => (
     <BlogGridCard


### PR DESCRIPTION
Removed the 'reverse()' function
Fixes #67